### PR TITLE
feat: precompiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,25 @@ From the previous section on binary tree flattening, we can derive the below arr
 # Tree Chaining
 
 By using the output of a tree as the input of a another tree, it is possible to chain trees together. Tree chaining is made possible thanks to the use of a
-memory array. The output of each tree is stored in this array and can be accessed using the MEM opcode.
+stack. The output of each tree is stored in this array and can be accessed using the STACK opcode.
 An example of the use of the chaining of trees can be found in `tests/test_tree.cairo::test_execute_tree_chain`.
 
 # Available Opcodes
 
-| Opcode | Description                                                                                                                                                                                                                          | Tested |
-| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
-| ADD    | Addition of left and right values                                                                                                                                                                                                    | ✅     |
-| SUB    | Substraction of left and right values                                                                                                                                                                                                | ✅     |
-| MUL    | Multiplication of left and right values                                                                                                                                                                                              | ✅     |
-| DIV    | Division of left and right values                                                                                                                                                                                                    | ✅     |
-| MOD    | Modulus of left and right values                                                                                                                                                                                                     | ✅     |
-| ABS    | Absolute of right value                                                                                                                                                                                                              | ✅     |
-| SQRT   | Square root of right value                                                                                                                                                                                                           | ✅     |
-| POW    | Left value to the power of right value                                                                                                                                                                                               | ✅     |
-| IS_NN  | 1 if right value >= 0, else 0                                                                                                                                                                                                        | ✅     |
-| IS_LE  | 1 if left value <= right value, else 0                                                                                                                                                                                               | ✅     |
-| NOT    | 1 if right value is 0, else 0                                                                                                                                                                                                        | ✅     |
-| EQ     | 1 if left value == right value, else 0                                                                                                                                                                                               | ✅     |
-| MEM    | Access the indexed values of previous trees output                                                                                                                                                                                   | ✅     |
-| DICT   | Access values stored in the passed dictionary                                                                                                                                                                                        | ✅     |
-| FUNC   | Access to the general purpose functions stored in <br /> the functions dictionary, allowing to evaluate a sub tree. <br /> The output of the subtree evaluation is saved in <br /> the memory array, accessable with the MEM opcode. | ✅     |
+| Opcode  | Description                                                                                                                                                                                           | Tested |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| ADD     | Addition of left and right values                                                                                                                                                                     | ✅     |
+| SUB     | Substraction of left and right values                                                                                                                                                                 | ✅     |
+| MUL     | Multiplication of left and right values                                                                                                                                                               | ✅     |
+| DIV     | Division of left and right values                                                                                                                                                                     | ✅     |
+| MOD     | Modulus of left and right values                                                                                                                                                                      | ✅     |
+| ABS     | Absolute of right value                                                                                                                                                                               | ✅     |
+| SQRT    | Square root of right value                                                                                                                                                                            | ✅     |
+| POW     | Left value to the power of right value                                                                                                                                                                | ✅     |
+| IS_NN   | 1 if right value >= 0, else 0                                                                                                                                                                         | ✅     |
+| IS_LE   | 1 if left value <= right value, else 0                                                                                                                                                                | ✅     |
+| NOT     | 1 if right value is 0, else 0                                                                                                                                                                         | ✅     |
+| EQ      | 1 if left value == right value, else 0                                                                                                                                                                | ✅     |
+| STACK   | Access the indexed values in the stack                                                                                                                                                                | ✅     |
+| HEAP    | Access values stored in the heap                                                                                                                                                                      | ✅     |
+| PRECOMP | Access to the precompiles stored in <br /> a dictionary, allowing to evaluate a sub tree. <br /> The output of the subtree evaluation is saved on <br /> the stack, accessable with the STACK opcode. | ✅     |

--- a/lib/constants.cairo
+++ b/lib/constants.cairo
@@ -13,7 +13,7 @@ mod opcodes {
     const NOT: u128 = 11_u128;
     const EQ: u128 = 12_u128;
 
-    const MEM: u128 = 13_u128;
-    const DICT: u128 = 14_u128;
-    const FUNC: u128 = 15_u128;
+    const STACK: u128 = 13_u128;
+    const HEAP: u128 = 14_u128;
+    const PRECOMP: u128 = 15_u128;
 }

--- a/lib/tests.cairo
+++ b/lib/tests.cairo
@@ -1,7 +1,12 @@
 // Corelib imports
 use array::ArrayTrait;
+use array::SpanTrait;
+use box::BoxTrait;
+use debug::PrintTrait;
 use dict::Felt252DictTrait;
+use nullable::nullable_from_box;
 use option::OptionTrait;
+use traits::Into;
 
 // Internal imports
 use bto::tree;
@@ -9,15 +14,26 @@ use bto::tree::Node;
 use bto::constants::opcodes;
 
 fn execute_tree(
-    ref tree: Array<Node>, ref stack: Array<u128>, heap: Option<Felt252Dict<u128>>
+    ref tree: Array<Node>,
+    stack: Option<Array<u128>>,
+    heap: Option<Felt252Dict<u128>>,
+    precompiles: Option<Felt252Dict<Nullable<Span<Node>>>>
 ) -> u128 {
     let mut tree_span = tree.span();
-    let mut stack_span = stack.span();
+
+    let mut stack = match stack {
+        Option::Some(s) => s.span(),
+        Option::None(()) => ArrayTrait::new().span()
+    };
     let mut heap = match heap {
         Option::Some(h) => h,
         Option::None(()) => Felt252DictTrait::new()
     };
-    tree::execute(ref tree_span, ref stack_span, ref heap)
+    let mut precompiles = match precompiles {
+        Option::Some(p) => p,
+        Option::None(()) => Felt252DictTrait::new()
+    };
+    tree::execute(ref tree_span, ref stack, ref heap, ref precompiles)
 }
 
 impl OptionDestruct<T, impl TDestruct: Destruct<T>> of Destruct<Option<T>> {
@@ -39,7 +55,6 @@ fn test_add__should_add_two_values() {
     //     add(2)   6(5)
     //    /   \
     // 1(3)   2(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::ADD, left: 1_usize, right: 6_usize });
     tree_array.append(Node { value: opcodes::ADD, left: 1_usize, right: 4_usize });
@@ -50,7 +65,7 @@ fn test_add__should_add_two_values() {
     tree_array.append(Node { value: 8, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 17, 'incorrect addition result');
@@ -68,7 +83,6 @@ fn test_sub__should_sub_two_values() {
     //     sub(2)   9(5)
     //    /   \
     // 1000(3) 15(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::SUB, left: 1_usize, right: 6_usize });
     tree_array.append(Node { value: opcodes::SUB, left: 1_usize, right: 4_usize });
@@ -79,7 +93,7 @@ fn test_sub__should_sub_two_values() {
     tree_array.append(Node { value: 245, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 731, 'incorrect substraction result');
@@ -97,7 +111,6 @@ fn test_mul__should_mul_two_values() {
     //     mul(2)   9(5)
     //    /   \
     // 13(3) 15(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 6_usize });
     tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
@@ -108,7 +121,7 @@ fn test_mul__should_mul_two_values() {
     tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 3510, 'incorrect multiplication result');
@@ -126,7 +139,6 @@ fn test_div__should_div_two_values() {
     //     div(2)   2(5)
     //    /   \
     // 512(3) 4(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::DIV, left: 1_usize, right: 6_usize });
     tree_array.append(Node { value: opcodes::DIV, left: 1_usize, right: 4_usize });
@@ -137,7 +149,7 @@ fn test_div__should_div_two_values() {
     tree_array.append(Node { value: 6, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 10, 'incorrect division result');
@@ -145,7 +157,7 @@ fn test_div__should_div_two_values() {
 
 #[test]
 #[available_gas(2000000)]
-fn test_mod__should_mod_two_values() {
+fn test_mod__should_mod() {
     // Given 
     // test case:
     //            mod(0)
@@ -155,7 +167,6 @@ fn test_mod__should_mod_two_values() {
     //     mod(2)   63(5)
     //    /   \
     // 512(3) 104(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::MOD, left: 1_usize, right: 6_usize });
     tree_array.append(Node { value: opcodes::MOD, left: 1_usize, right: 4_usize });
@@ -166,7 +177,7 @@ fn test_mod__should_mod_two_values() {
     tree_array.append(Node { value: 7, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 5, 'incorrect modulo result');
@@ -174,7 +185,7 @@ fn test_mod__should_mod_two_values() {
 
 #[test]
 #[available_gas(2000000)]
-fn test_sqrt__should_sqrt_one_value() {
+fn test_sqrt__should_sqrt() {
     // Given 
     // Tree
     //           sqrt(0)
@@ -184,7 +195,6 @@ fn test_sqrt__should_sqrt_one_value() {
     //     sqrt(2)   5(4)
     //       |
     //      400(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::SQRT, left: 0_usize, right: 1_usize });
     tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 3_usize });
@@ -193,7 +203,7 @@ fn test_sqrt__should_sqrt_one_value() {
     tree_array.append(Node { value: 5, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 10, 'incorrect sqrt result');
@@ -211,7 +221,6 @@ fn test_is_le__should_evaluate_is_le_two_values() {
     //     is_le(2)   2(5)
     //    /   \
     // 2(3) 6(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 6_usize });
     tree_array.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 4_usize });
@@ -222,7 +231,7 @@ fn test_is_le__should_evaluate_is_le_two_values() {
     tree_array.append(Node { value: 0, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 0, 'incorrect is less than result');
@@ -230,7 +239,7 @@ fn test_is_le__should_evaluate_is_le_two_values() {
 
 #[test]
 #[available_gas(2000000)]
-fn test_not__should_evaluate_not_one_value() {
+fn test_not__should_evaluate_not() {
     // Given 
     // Tree
     //           not(0)
@@ -240,7 +249,6 @@ fn test_not__should_evaluate_not_one_value() {
     //     not(2)   -1(4)
     //       |
     //      1(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::NOT, left: 0_usize, right: 1_usize });
     tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 3_usize });
@@ -249,7 +257,7 @@ fn test_not__should_evaluate_not_one_value() {
     tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 1, 'incorrect not result');
@@ -257,7 +265,7 @@ fn test_not__should_evaluate_not_one_value() {
 
 #[test]
 #[available_gas(2000000)]
-fn test_eq__should_evaluate_eq_two_value() {
+fn test_eq__should_evaluate_eq() {
     // Given 
     // Tree
     //            eq(0)
@@ -267,7 +275,6 @@ fn test_eq__should_evaluate_eq_two_value() {
     //     eq(2)   5(5)
     //    /   \
     // 2(3) 3(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::EQ, left: 1_usize, right: 6_usize });
     tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
@@ -278,7 +285,7 @@ fn test_eq__should_evaluate_eq_two_value() {
     tree_array.append(Node { value: 0, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
     assert(result == 1, 'incorrect eq result');
@@ -286,7 +293,7 @@ fn test_eq__should_evaluate_eq_two_value() {
 
 #[test]
 #[available_gas(2000000)]
-fn test_mem__should_evaluate_mem_one_value() {
+fn test_mem__should_evaluate_mem() {
     // Given 
     // Tree
     //           mem(0)
@@ -312,7 +319,9 @@ fn test_mem__should_evaluate_mem_one_value() {
     tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::None(()));
+    let result = execute_tree(
+        ref tree_array, Option::Some(stack), Option::None(()), Option::None(())
+    );
 
     // Then
     assert(result == 5, 'incorrect mem result');
@@ -320,7 +329,7 @@ fn test_mem__should_evaluate_mem_one_value() {
 
 #[test]
 #[available_gas(2000000)]
-fn test_dict__should_evaluate_dict_one_value() {
+fn test_dict__should_evaluate_dict() {
     // Given 
     // Tree
     //           dict(0)
@@ -330,7 +339,6 @@ fn test_dict__should_evaluate_dict_one_value() {
     //     dict(2)   2(4)
     //       |
     //      100(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut heap = Felt252DictTrait::new();
     heap.insert(100, 22_u128);
     heap.insert(44, 17_u128);
@@ -343,8 +351,101 @@ fn test_dict__should_evaluate_dict_one_value() {
     tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
 
     // When
-    let result = execute_tree(ref tree_array, ref stack, Option::Some(heap));
+    let result = execute_tree(
+        ref tree_array, Option::None(()), Option::Some(heap), Option::None(())
+    );
 
     // Then
     assert(result == 17, 'incorrect dict result');
 }
+
+#[test]
+#[available_gas(20000000)]
+fn test_precompiles__should_evaluate_precompile() {
+    // Given 
+    // Tree 1:
+    //           func(0)
+    //            |
+    //         div(1)
+    //       /      \
+    //     func(2)   99(4)
+    //       |
+    //      0(3)
+    //
+    // Func 0 (output = 99):
+    //                     mul(0)
+    //               /              \
+    //            mul(1)           sub(13)
+    //           /     \            /   \    
+    //       is_le(2)  sub(7)   sqrt(16) not(14) 
+    //      /  \         /  \     |       |      
+    // mul(3) 65(6) 30(8) mod(9) 150(17) 0(15)  
+    //   / \                 /   \      
+    // 2(4) 32(5)      350(10) 47(11)   
+    //
+    // Func 1 (output = 70):
+    //                 mul(0)
+    //               /       \
+    //            mul(1)     add(8)
+    //           /     \      /   \
+    //       mod(2)  sub(5)  3(9)  4(10)
+    //      /  \     /    \          
+    // 47(3)  7(4) 30(6) 28(7)   
+
+    let mut stack: Array<u128> = ArrayTrait::new();
+    let mut precompiles: Felt252Dict<Nullable<Span<Node>>> = Felt252DictTrait::new();
+
+    let mut precompiles_first: Array<Node> = ArrayTrait::new();
+    precompiles_first.append(Node { value: opcodes::MUL, left: 1_usize, right: 12_usize });
+    precompiles_first.append(Node { value: opcodes::MUL, left: 1_usize, right: 6_usize });
+    precompiles_first.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 4_usize });
+    precompiles_first.append(Node { value: opcodes::MUL, left: 1_usize, right: 2_usize });
+    precompiles_first.append(Node { value: 2, left: 0_usize, right: 0_usize });
+    precompiles_first.append(Node { value: 32, left: 0_usize, right: 0_usize });
+    precompiles_first.append(Node { value: 65, left: 0_usize, right: 0_usize });
+    precompiles_first.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
+    precompiles_first.append(Node { value: 30, left: 0_usize, right: 0_usize });
+    precompiles_first.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
+    precompiles_first.append(Node { value: 350, left: 0_usize, right: 0_usize });
+    precompiles_first.append(Node { value: 47, left: 0_usize, right: 0_usize });
+    precompiles_first.append(Node { value: opcodes::SUB, left: 1_usize, right: 3_usize });
+    precompiles_first.append(Node { value: opcodes::SQRT, left: 0_usize, right: 1_usize });
+    precompiles_first.append(Node { value: 150, left: 0_usize, right: 0_usize });
+    precompiles_first.append(Node { value: opcodes::NOT, left: 0_usize, right: 1_usize });
+    precompiles_first.append(Node { value: 0, left: 0_usize, right: 0_usize });
+
+    let mut precompile_first: Box<Span<Node>> = BoxTrait::new(precompiles_first.span());
+    precompiles.insert(0, nullable_from_box(precompile_first));
+
+    let mut precompiles_second: Array<Node> = ArrayTrait::new();
+    precompiles_second.append(Node { value: opcodes::MUL, left: 1_usize, right: 8_usize });
+    precompiles_second.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
+    precompiles_second.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
+    precompiles_second.append(Node { value: 47, left: 0_usize, right: 0_usize });
+    precompiles_second.append(Node { value: 7, left: 0_usize, right: 0_usize });
+    precompiles_second.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
+    precompiles_second.append(Node { value: 30, left: 0_usize, right: 0_usize });
+    precompiles_second.append(Node { value: 28, left: 0_usize, right: 0_usize });
+    precompiles_second.append(Node { value: opcodes::ADD, left: 1_usize, right: 2_usize });
+    precompiles_second.append(Node { value: 3, left: 0_usize, right: 0_usize });
+    precompiles_second.append(Node { value: 4, left: 0_usize, right: 0_usize });
+
+    let mut precompile_second: Box<Span<Node>> = BoxTrait::new(precompiles_second.span());
+    precompiles.insert(1, nullable_from_box(precompile_second));
+
+    let mut tree_array: Array<Node> = ArrayTrait::new();
+    tree_array.append(Node { value: opcodes::FUNC, left: 0_usize, right: 1_usize });
+    tree_array.append(Node { value: opcodes::DIV, left: 1_usize, right: 3_usize });
+    tree_array.append(Node { value: opcodes::FUNC, left: 0_usize, right: 1_usize });
+    tree_array.append(Node { value: 0, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: 99, left: 0_usize, right: 0_usize });
+
+    // When
+    let result = execute_tree(
+        ref tree_array, Option::None(()), Option::None(()), Option::Some(precompiles)
+    );
+
+    // Then
+    assert(result == 70, 'incorrect precompile result');
+}
+

--- a/lib/tests.cairo
+++ b/lib/tests.cairo
@@ -366,15 +366,15 @@ fn test_precompiles__should_evaluate_precompile() {
     // Tree:
     //              add(0)
     //            /        \
-    //           func(1)  mem(6)
+    //        precomp(1)  mem(6)
     //            |         |
     //         div(2)       0
     //       /      \
-    //     func(3)   99(5)
+    //  precomp(3)   99(5)
     //       |
     //      0(4)
     //
-    // Func 0 (output = 99):
+    // Precompile 0 (output = 99):
     //                     mul(0)
     //               /              \
     //            mul(1)           sub(13)
@@ -385,7 +385,7 @@ fn test_precompiles__should_evaluate_precompile() {
     //   / \                 /   \      
     // 2(4) 32(5)      350(10) 47(11)   
     //
-    // Func 1 (output = 70):
+    // Precompile 1 (output = 70):
     //                 mul(0)
     //               /       \
     //            mul(1)     add(8)
@@ -397,43 +397,43 @@ fn test_precompiles__should_evaluate_precompile() {
     let mut stack: Array<u128> = ArrayTrait::new();
     let mut precompiles: Felt252Dict<Nullable<Span<Node>>> = Felt252DictTrait::new();
 
-    let mut precompiles_first: Array<Node> = ArrayTrait::new();
-    precompiles_first.append(Node { value: opcodes::MUL, left: 1_usize, right: 12_usize });
-    precompiles_first.append(Node { value: opcodes::MUL, left: 1_usize, right: 6_usize });
-    precompiles_first.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 4_usize });
-    precompiles_first.append(Node { value: opcodes::MUL, left: 1_usize, right: 2_usize });
-    precompiles_first.append(Node { value: 2, left: 0_usize, right: 0_usize });
-    precompiles_first.append(Node { value: 32, left: 0_usize, right: 0_usize });
-    precompiles_first.append(Node { value: 65, left: 0_usize, right: 0_usize });
-    precompiles_first.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
-    precompiles_first.append(Node { value: 30, left: 0_usize, right: 0_usize });
-    precompiles_first.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
-    precompiles_first.append(Node { value: 350, left: 0_usize, right: 0_usize });
-    precompiles_first.append(Node { value: 47, left: 0_usize, right: 0_usize });
-    precompiles_first.append(Node { value: opcodes::SUB, left: 1_usize, right: 3_usize });
-    precompiles_first.append(Node { value: opcodes::SQRT, left: 0_usize, right: 1_usize });
-    precompiles_first.append(Node { value: 150, left: 0_usize, right: 0_usize });
-    precompiles_first.append(Node { value: opcodes::NOT, left: 0_usize, right: 1_usize });
-    precompiles_first.append(Node { value: 0, left: 0_usize, right: 0_usize });
+    let mut precompile_one: Array<Node> = ArrayTrait::new();
+    precompile_one.append(Node { value: opcodes::MUL, left: 1_usize, right: 12_usize });
+    precompile_one.append(Node { value: opcodes::MUL, left: 1_usize, right: 6_usize });
+    precompile_one.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 4_usize });
+    precompile_one.append(Node { value: opcodes::MUL, left: 1_usize, right: 2_usize });
+    precompile_one.append(Node { value: 2, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: 32, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: 65, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
+    precompile_one.append(Node { value: 30, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
+    precompile_one.append(Node { value: 350, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: 47, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: opcodes::SUB, left: 1_usize, right: 3_usize });
+    precompile_one.append(Node { value: opcodes::SQRT, left: 0_usize, right: 1_usize });
+    precompile_one.append(Node { value: 150, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: opcodes::NOT, left: 0_usize, right: 1_usize });
+    precompile_one.append(Node { value: 0, left: 0_usize, right: 0_usize });
 
-    let mut precompile_first: Box<Span<Node>> = BoxTrait::new(precompiles_first.span());
-    precompiles.insert(0, nullable_from_box(precompile_first));
+    let mut precompile_one: Box<Span<Node>> = BoxTrait::new(precompile_one.span());
+    precompiles.insert(0, nullable_from_box(precompile_one));
 
-    let mut precompiles_second: Array<Node> = ArrayTrait::new();
-    precompiles_second.append(Node { value: opcodes::MUL, left: 1_usize, right: 8_usize });
-    precompiles_second.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
-    precompiles_second.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
-    precompiles_second.append(Node { value: 47, left: 0_usize, right: 0_usize });
-    precompiles_second.append(Node { value: 7, left: 0_usize, right: 0_usize });
-    precompiles_second.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
-    precompiles_second.append(Node { value: 30, left: 0_usize, right: 0_usize });
-    precompiles_second.append(Node { value: 28, left: 0_usize, right: 0_usize });
-    precompiles_second.append(Node { value: opcodes::ADD, left: 1_usize, right: 2_usize });
-    precompiles_second.append(Node { value: 3, left: 0_usize, right: 0_usize });
-    precompiles_second.append(Node { value: 4, left: 0_usize, right: 0_usize });
+    let mut precompile_two: Array<Node> = ArrayTrait::new();
+    precompile_two.append(Node { value: opcodes::MUL, left: 1_usize, right: 8_usize });
+    precompile_two.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
+    precompile_two.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
+    precompile_two.append(Node { value: 47, left: 0_usize, right: 0_usize });
+    precompile_two.append(Node { value: 7, left: 0_usize, right: 0_usize });
+    precompile_two.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
+    precompile_two.append(Node { value: 30, left: 0_usize, right: 0_usize });
+    precompile_two.append(Node { value: 28, left: 0_usize, right: 0_usize });
+    precompile_two.append(Node { value: opcodes::ADD, left: 1_usize, right: 2_usize });
+    precompile_two.append(Node { value: 3, left: 0_usize, right: 0_usize });
+    precompile_two.append(Node { value: 4, left: 0_usize, right: 0_usize });
 
-    let mut precompile_second: Box<Span<Node>> = BoxTrait::new(precompiles_second.span());
-    precompiles.insert(1, nullable_from_box(precompile_second));
+    let mut precompile_two: Box<Span<Node>> = BoxTrait::new(precompile_two.span());
+    precompiles.insert(1, nullable_from_box(precompile_two));
 
     let mut tree_array: Array<Node> = ArrayTrait::new();
     tree_array.append(Node { value: opcodes::ADD, left: 1_usize, right: 6_usize });

--- a/lib/tree.cairo
+++ b/lib/tree.cairo
@@ -3,6 +3,7 @@ use array::ArrayTrait;
 use array::SpanTrait;
 use dict::Felt252DictTrait;
 use integer::u128_sqrt;
+use nullable::NullableTrait;
 use option::OptionTrait;
 use traits::Into;
 use traits::TryInto;
@@ -26,7 +27,12 @@ struct Node {
 // TODO: add ABS once we have signed integers
 // TODO: add IS_NN once we have signed integers
 // TODO: import quaireaux_math and use it for POW
-fn execute(ref tree: Span<Node>, ref stack: Span<u128>, ref heap: Felt252Dict<u128>) -> u128 {
+fn execute(
+    ref tree: Span<Node>,
+    ref stack: Span<u128>,
+    ref heap: Felt252Dict<u128>,
+    ref precompiles: Felt252Dict<Nullable<Span<Node>>>
+) -> u128 {
     match gas::withdraw_gas() {
         Option::Some(_) => (),
         Option::None(_) => {
@@ -51,12 +57,12 @@ fn execute(ref tree: Span<Node>, ref stack: Span<u128>, ref heap: Felt252Dict<u1
     }
 
     let mut tree_slice_right = tree.slice(right_offset, length - right_offset);
-    let value_right = execute(ref tree_slice_right, ref stack, ref heap);
+    let value_right: u128 = execute(ref tree_slice_right, ref stack, ref heap, ref precompiles);
 
     let mut value_left = 0_u128;
     if left_offset != 0_usize {
         let mut tree_slice_left = tree.slice(left_offset, right_offset - left_offset);
-        value_left = execute(ref tree_slice_left, ref stack, ref heap);
+        value_left = execute(ref tree_slice_left, ref stack, ref heap, ref precompiles);
     }
 
     if value == opcodes::ADD {
@@ -80,7 +86,7 @@ fn execute(ref tree: Span<Node>, ref stack: Span<u128>, ref heap: Felt252Dict<u1
     }
 
     if value == opcodes::SQRT {
-        return u128_sqrt(value_right);
+        return integer::upcast(u128_sqrt(value_right));
     }
 
     if value == opcodes::IS_LE {
@@ -111,6 +117,11 @@ fn execute(ref tree: Span<Node>, ref stack: Span<u128>, ref heap: Felt252Dict<u1
 
     if value == opcodes::DICT {
         return heap.get(value_right.into());
+    }
+
+    if value == opcodes::FUNC {
+        let mut precompile = precompiles.get(value_right.into()).deref();
+        return execute(ref precompile, ref stack, ref heap, ref precompiles);
     }
 
     assert(false, 'Invalid opcode');


### PR DESCRIPTION
### Description 
Augments the currents binary tree operator (BTO), adding a precompile implementation which allows precompiles functions to be called within a tree .

### Approach
The precompiles are integrated using tests from Cairo 0.X implementation.

### Checklist
- [x] Update current validated tests of the BTO for precompiles to Cairo 1.0
- [x] Implement the BTO in order to pass the updated tests for precompiles