### PR TITLE
feat: signed ints

### DIFF
--- a/lib/lib.cairo
+++ b/lib/lib.cairo
@@ -1,5 +1,7 @@
 mod constants;
 
+mod math;
+
 #[cfg(test)]
 mod tests;
 

--- a/lib/lib.cairo
+++ b/lib/lib.cairo
@@ -1,6 +1,8 @@
-mod tree;
-
 mod constants;
 
 #[cfg(test)]
 mod tests;
+
+mod tree;
+
+mod types;

--- a/lib/math.cairo
+++ b/lib/math.cairo
@@ -1,0 +1,30 @@
+//! # Fast power algorithm
+use array::ArrayTrait;
+
+// from https://github.com/keep-starknet-strange/quaireaux/blob/main/quaireaux/math/src/fast_power.cairo
+// Calculate the (base^power)mod modulus using the fast powering algorithm
+// # Arguments
+// * `base` - The base of the exponentiation
+// * `power` - The power of the exponentiation
+// * `modulus` - The modulus used in the calculation
+// # Returns
+// * `felt252` - The result of (base^power)mod modulus
+fn fast_power(mut base: u128, mut power: u128, modulus: u128) -> u128 {
+    // Return invalid input error
+    if base == 0 {
+        panic_with_felt252('II')
+    }
+
+    let mut result = 1;
+    loop {
+        if power == 0 {
+            break result;
+        }
+
+        if power % 2 != 0 {
+            result = (result * base) % modulus;
+        }
+        base = (base * base) % modulus;
+        power = power / 2;
+    }
+}

--- a/lib/tests.cairo
+++ b/lib/tests.cairo
@@ -242,6 +242,34 @@ fn test_sqrt__should_sqrt() {
 
 #[test]
 #[available_gas(2000000)]
+fn test_mod__should_pow() {
+    // Given 
+    // Tree
+    //            pow(0)
+    //          /       \
+    //         pow(1)   2(6)
+    //       /      \
+    //     pow(2)   2(5)
+    //    /   \
+    // 2(3)   6(4)
+    let mut tree_array: Array<Node> = ArrayTrait::new();
+    tree_array.append(Node { value: i129Trait::new(opcodes::POW), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::POW), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::POW), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(6_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+
+    // When
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
+
+    // Then
+    assert(result.inner == 16777216, 'incorrect pow result');
+}
+
+#[test]
+#[available_gas(2000000)]
 fn test_mod__should_is_nn() {
     // Given 
     // Tree

--- a/lib/tests.cairo
+++ b/lib/tests.cairo
@@ -189,6 +189,33 @@ fn test_mod__should_mod() {
 
 #[test]
 #[available_gas(2000000)]
+fn test_mod__should_abs() {
+    // Given 
+    // Tree
+    //           abs(0)
+    //            |
+    //         mult(1)
+    //       /      \
+    //     abs(2)   -2(4)
+    //       |
+    //      -100(3)
+    let mut tree_array: Array<Node> = ArrayTrait::new();
+    tree_array.append(Node { value: i129Trait::new(opcodes::ABS), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 3 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::ABS), left: 0, right: 1 });
+    tree_array.append(Node { value: -i129Trait::new(100_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: -i129Trait::new(2_u128), left: 0, right: 0 });
+
+    // When
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
+
+    // Then
+    assert(result.inner == 200, 'incorrect abs result');
+    assert(!result.sign, 'incorrect abs result');
+}
+
+#[test]
+#[available_gas(2000000)]
 fn test_sqrt__should_sqrt() {
     // Given 
     // Tree
@@ -211,6 +238,32 @@ fn test_sqrt__should_sqrt() {
 
     // Then
     assert(result.inner == 10, 'incorrect sqrt result');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn test_mod__should_is_nn() {
+    // Given 
+    // Tree
+    //           is_nn(0)
+    //            |
+    //         mul(1)
+    //       /      \
+    //     is_nn(2)   -1(4)
+    //       |
+    //      10(3)
+    let mut tree_array: Array<Node> = ArrayTrait::new();
+    tree_array.append(Node { value: i129Trait::new(opcodes::IS_NN), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 3 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::IS_NN), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(10_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: -i129Trait::new(1_u128), left: 0, right: 0 });
+
+    // When
+    let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
+
+    // Then
+    assert(result.inner == 0, 'incorrect abs result');
 }
 
 #[test]

--- a/lib/tests.cairo
+++ b/lib/tests.cairo
@@ -9,16 +9,20 @@ use option::OptionTrait;
 use traits::Into;
 
 // Internal imports
+use bto::constants::opcodes;
 use bto::tree;
 use bto::tree::Node;
-use bto::constants::opcodes;
+use bto::types::i129;
+use bto::types::i129Trait;
+
+// TODO remove all the _usize (since Cairo 1.0 has inference)
 
 fn execute_tree(
     ref tree: Array<Node>,
-    stack: Option<Array<u128>>,
-    heap: Option<Felt252Dict<u128>>,
+    stack: Option<Array<i129>>,
+    heap: Option<Felt252Dict<Nullable<i129>>>,
     precompiles: Option<Felt252Dict<Nullable<Span<Node>>>>
-) -> u128 {
+) -> i129 {
     let mut tree_span = tree.span();
 
     let mut stack = match stack {
@@ -56,19 +60,19 @@ fn test_add__should_add_two_values() {
     //    /   \
     // 1(3)   2(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::ADD, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::ADD, left: 1_usize, right: 4_usize });
-    tree_array.append(Node { value: opcodes::ADD, left: 1_usize, right: 2_usize });
-    tree_array.append(Node { value: 1, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 6, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 8, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::ADD), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::ADD), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::ADD), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(1_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(6_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(8_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 17, 'incorrect addition result');
+    assert(result.inner == 17, 'incorrect addition result');
 }
 
 #[test]
@@ -84,19 +88,19 @@ fn test_sub__should_sub_two_values() {
     //    /   \
     // 1000(3) 15(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::SUB, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::SUB, left: 1_usize, right: 4_usize });
-    tree_array.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
-    tree_array.append(Node { value: 1000, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 15, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 9, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 245, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::SUB), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::SUB), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::SUB), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(1000_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(15_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(9_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(245_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 731, 'incorrect substraction result');
+    assert(result.inner == 731, 'incorrect substraction result');
 }
 
 #[test]
@@ -112,19 +116,19 @@ fn test_mul__should_mul_two_values() {
     //    /   \
     // 13(3) 15(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 2_usize });
-    tree_array.append(Node { value: 13, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 15, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 9, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(13_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(15_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(9_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 3510, 'incorrect multiplication result');
+    assert(result.inner == 3510, 'incorrect multiplication result');
 }
 
 #[test]
@@ -140,19 +144,19 @@ fn test_div__should_div_two_values() {
     //    /   \
     // 512(3) 4(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::DIV, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::DIV, left: 1_usize, right: 4_usize });
-    tree_array.append(Node { value: opcodes::DIV, left: 1_usize, right: 2_usize });
-    tree_array.append(Node { value: 512, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 4, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 6, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::DIV), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::DIV), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::DIV), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(512_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(4_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(6_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 10, 'incorrect division result');
+    assert(result.inner == 10, 'incorrect division result');
 }
 
 #[test]
@@ -168,19 +172,19 @@ fn test_mod__should_mod() {
     //    /   \
     // 512(3) 104(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::MOD, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::MOD, left: 1_usize, right: 4_usize });
-    tree_array.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
-    tree_array.append(Node { value: 512, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 104, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 63, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 7, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MOD), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MOD), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MOD), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(512_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(104_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(63_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(7_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 5, 'incorrect modulo result');
+    assert(result.inner == 5, 'incorrect modulo result');
 }
 
 #[test]
@@ -196,17 +200,17 @@ fn test_sqrt__should_sqrt() {
     //       |
     //      400(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::SQRT, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 3_usize });
-    tree_array.append(Node { value: opcodes::SQRT, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: 400, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 5, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::SQRT), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 3 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::SQRT), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(400_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(5_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 10, 'incorrect sqrt result');
+    assert(result.inner == 10, 'incorrect sqrt result');
 }
 
 #[test]
@@ -222,19 +226,19 @@ fn test_is_le__should_evaluate_is_le_two_values() {
     //    /   \
     // 2(3) 6(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 4_usize });
-    tree_array.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 2_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 6, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 0, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::IS_LE), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::IS_LE), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::IS_LE), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(6_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(0_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 0, 'incorrect is less than result');
+    assert(result.inner == 0, 'incorrect is less than result');
 }
 
 #[test]
@@ -250,17 +254,17 @@ fn test_not__should_evaluate_not() {
     //       |
     //      1(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::NOT, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 3_usize });
-    tree_array.append(Node { value: opcodes::NOT, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: 1, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::NOT), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 3 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::NOT), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(1_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 1, 'incorrect not result');
+    assert(result.inner == 1, 'incorrect not result');
 }
 
 #[test]
@@ -276,19 +280,19 @@ fn test_eq__should_evaluate_eq() {
     //    /   \
     // 2(3) 3(3)
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::EQ, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
-    tree_array.append(Node { value: opcodes::EQ, left: 1_usize, right: 2_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 3, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 5, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 0, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::EQ), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 4 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::EQ), left: 1, right: 2 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(3_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(5_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(0_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(ref tree_array, Option::None(()), Option::None(()), Option::None(()));
 
     // Then
-    assert(result == 1, 'incorrect eq result');
+    assert(result.inner == 1, 'incorrect eq result');
 }
 
 #[test]
@@ -303,20 +307,20 @@ fn test_stack__should_evaluate_stack() {
     //     stack(2)   2(4)
     //       |
     //      1(3)
-    let mut stack: Array<u128> = ArrayTrait::new();
-    stack.append(1_u128);
-    stack.append(2_u128);
-    stack.append(3_u128);
-    stack.append(4_u128);
-    stack.append(5_u128);
-    stack.append(6_u128);
+    let mut stack: Array<i129> = ArrayTrait::new();
+    stack.append(i129Trait::new(1_u128));
+    stack.append(i129Trait::new(2_u128));
+    stack.append(i129Trait::new(3_u128));
+    stack.append(i129Trait::new(4_u128));
+    stack.append(i129Trait::new(5_u128));
+    stack.append(i129Trait::new(6_u128));
 
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::STACK, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 3_usize });
-    tree_array.append(Node { value: opcodes::STACK, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: 1, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::STACK), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 3 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::STACK), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(1_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(
@@ -324,7 +328,7 @@ fn test_stack__should_evaluate_stack() {
     );
 
     // Then
-    assert(result == 5, 'incorrect stack result');
+    assert(result.inner == 5, 'incorrect stack result');
 }
 
 #[test]
@@ -340,15 +344,15 @@ fn test_heap__should_evaluate_heap() {
     //       |
     //      100(3)
     let mut heap = Felt252DictTrait::new();
-    heap.insert(100, 22_u128);
-    heap.insert(44, 17_u128);
+    heap.insert(100, i129Trait::new(22_u128).into());
+    heap.insert(44, i129Trait::new(17_u128).into());
 
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::HEAP, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: opcodes::MUL, left: 1_usize, right: 3_usize });
-    tree_array.append(Node { value: opcodes::HEAP, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: 100, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 2, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::HEAP), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 3 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::HEAP), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(100_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(
@@ -356,7 +360,7 @@ fn test_heap__should_evaluate_heap() {
     );
 
     // Then
-    assert(result == 17, 'incorrect heap result');
+    assert(result.inner == 17, 'incorrect heap result');
 }
 
 #[test]
@@ -394,56 +398,55 @@ fn test_precompiles__should_evaluate_precompile() {
     //      /  \     /    \          
     // 47(3)  7(4) 30(6) 28(7)   
 
-    let mut stack: Array<u128> = ArrayTrait::new();
     let mut precompiles: Felt252Dict<Nullable<Span<Node>>> = Felt252DictTrait::new();
 
     let mut precompile_one: Array<Node> = ArrayTrait::new();
-    precompile_one.append(Node { value: opcodes::MUL, left: 1_usize, right: 12_usize });
-    precompile_one.append(Node { value: opcodes::MUL, left: 1_usize, right: 6_usize });
-    precompile_one.append(Node { value: opcodes::IS_LE, left: 1_usize, right: 4_usize });
-    precompile_one.append(Node { value: opcodes::MUL, left: 1_usize, right: 2_usize });
-    precompile_one.append(Node { value: 2, left: 0_usize, right: 0_usize });
-    precompile_one.append(Node { value: 32, left: 0_usize, right: 0_usize });
-    precompile_one.append(Node { value: 65, left: 0_usize, right: 0_usize });
-    precompile_one.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
-    precompile_one.append(Node { value: 30, left: 0_usize, right: 0_usize });
-    precompile_one.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
-    precompile_one.append(Node { value: 350, left: 0_usize, right: 0_usize });
-    precompile_one.append(Node { value: 47, left: 0_usize, right: 0_usize });
-    precompile_one.append(Node { value: opcodes::SUB, left: 1_usize, right: 3_usize });
-    precompile_one.append(Node { value: opcodes::SQRT, left: 0_usize, right: 1_usize });
-    precompile_one.append(Node { value: 150, left: 0_usize, right: 0_usize });
-    precompile_one.append(Node { value: opcodes::NOT, left: 0_usize, right: 1_usize });
-    precompile_one.append(Node { value: 0, left: 0_usize, right: 0_usize });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 12 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 6 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::IS_LE), left: 1, right: 4 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 2 });
+    precompile_one.append(Node { value: i129Trait::new(2_u128), left: 0, right: 0 });
+    precompile_one.append(Node { value: i129Trait::new(32_u128), left: 0, right: 0 });
+    precompile_one.append(Node { value: i129Trait::new(65_u128), left: 0, right: 0 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::SUB), left: 1, right: 2 });
+    precompile_one.append(Node { value: i129Trait::new(30_u128), left: 0, right: 0 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::MOD), left: 1, right: 2 });
+    precompile_one.append(Node { value: i129Trait::new(350_u128), left: 0, right: 0 });
+    precompile_one.append(Node { value: i129Trait::new(47_u128), left: 0, right: 0 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::SUB), left: 1, right: 3 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::SQRT), left: 0, right: 1 });
+    precompile_one.append(Node { value: i129Trait::new(150_u128), left: 0, right: 0 });
+    precompile_one.append(Node { value: i129Trait::new(opcodes::NOT), left: 0, right: 1 });
+    precompile_one.append(Node { value: i129Trait::new(0_u128), left: 0, right: 0 });
 
     let mut precompile_one: Box<Span<Node>> = BoxTrait::new(precompile_one.span());
     precompiles.insert(0, nullable_from_box(precompile_one));
 
     let mut precompile_two: Array<Node> = ArrayTrait::new();
-    precompile_two.append(Node { value: opcodes::MUL, left: 1_usize, right: 8_usize });
-    precompile_two.append(Node { value: opcodes::MUL, left: 1_usize, right: 4_usize });
-    precompile_two.append(Node { value: opcodes::MOD, left: 1_usize, right: 2_usize });
-    precompile_two.append(Node { value: 47, left: 0_usize, right: 0_usize });
-    precompile_two.append(Node { value: 7, left: 0_usize, right: 0_usize });
-    precompile_two.append(Node { value: opcodes::SUB, left: 1_usize, right: 2_usize });
-    precompile_two.append(Node { value: 30, left: 0_usize, right: 0_usize });
-    precompile_two.append(Node { value: 28, left: 0_usize, right: 0_usize });
-    precompile_two.append(Node { value: opcodes::ADD, left: 1_usize, right: 2_usize });
-    precompile_two.append(Node { value: 3, left: 0_usize, right: 0_usize });
-    precompile_two.append(Node { value: 4, left: 0_usize, right: 0_usize });
+    precompile_two.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 8 });
+    precompile_two.append(Node { value: i129Trait::new(opcodes::MUL), left: 1, right: 4 });
+    precompile_two.append(Node { value: i129Trait::new(opcodes::MOD), left: 1, right: 2 });
+    precompile_two.append(Node { value: i129Trait::new(47_u128), left: 0, right: 0 });
+    precompile_two.append(Node { value: i129Trait::new(7_u128), left: 0, right: 0 });
+    precompile_two.append(Node { value: i129Trait::new(opcodes::SUB), left: 1, right: 2 });
+    precompile_two.append(Node { value: i129Trait::new(30_u128), left: 0, right: 0 });
+    precompile_two.append(Node { value: i129Trait::new(28_u128), left: 0, right: 0 });
+    precompile_two.append(Node { value: i129Trait::new(opcodes::ADD), left: 1, right: 2 });
+    precompile_two.append(Node { value: i129Trait::new(3_u128), left: 0, right: 0 });
+    precompile_two.append(Node { value: i129Trait::new(4_u128), left: 0, right: 0 });
 
     let mut precompile_two: Box<Span<Node>> = BoxTrait::new(precompile_two.span());
     precompiles.insert(1, nullable_from_box(precompile_two));
 
     let mut tree_array: Array<Node> = ArrayTrait::new();
-    tree_array.append(Node { value: opcodes::ADD, left: 1_usize, right: 6_usize });
-    tree_array.append(Node { value: opcodes::PRECOMP, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: opcodes::DIV, left: 1_usize, right: 3_usize });
-    tree_array.append(Node { value: opcodes::PRECOMP, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: 0, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: 99, left: 0_usize, right: 0_usize });
-    tree_array.append(Node { value: opcodes::STACK, left: 0_usize, right: 1_usize });
-    tree_array.append(Node { value: 0, left: 0_usize, right: 0_usize });
+    tree_array.append(Node { value: i129Trait::new(opcodes::ADD), left: 1, right: 6 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::PRECOMP), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::DIV), left: 1, right: 3 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::PRECOMP), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(0_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(99_u128), left: 0, right: 0 });
+    tree_array.append(Node { value: i129Trait::new(opcodes::STACK), left: 0, right: 1 });
+    tree_array.append(Node { value: i129Trait::new(0_u128), left: 0, right: 0 });
 
     // When
     let result = execute_tree(
@@ -451,6 +454,6 @@ fn test_precompiles__should_evaluate_precompile() {
     );
 
     // Then
-    assert(result == 169, 'incorrect precompile result');
+    assert(result.inner == 169, 'incorrect precompile result');
 }
 

--- a/lib/tree.cairo
+++ b/lib/tree.cairo
@@ -86,7 +86,9 @@ fn execute(
         return value_left % value_right;
     }
 
-    // TODO: add ABS
+    if opcode == opcodes::ABS {
+        return i129Trait::new(value_right.inner);
+    }
 
     if opcode == opcodes::SQRT {
         assert(value_right >= i129Trait::new(0_u128), 'sqrt(x) with x<0');
@@ -94,7 +96,12 @@ fn execute(
         return i129Trait::new(sqrt);
     }
 
-    // TODO: add IS_NN
+    if opcode == opcodes::IS_NN {
+        return match value_right >= i129Trait::new(0_u128) {
+            bool::False(()) => i129Trait::zero(),
+            bool::True(()) => i129Trait::one(),
+        };
+    }
 
     if opcode == opcodes::IS_LE {
         return match value_left <= value_right {

--- a/lib/tree.cairo
+++ b/lib/tree.cairo
@@ -2,6 +2,7 @@
 use array::ArrayTrait;
 use array::SpanTrait;
 use dict::Felt252DictTrait;
+use integer::BoundedInt;
 use integer::u128_sqrt;
 use nullable::NullableTrait;
 use option::OptionTrait;
@@ -12,6 +13,7 @@ use traits::TryInto;
 
 // Internal imports
 use bto::constants::opcodes;
+use bto::math::fast_power;
 use bto::types::i129;
 use bto::types::i129Trait;
 
@@ -94,6 +96,15 @@ fn execute(
         assert(value_right >= i129Trait::new(0_u128), 'sqrt(x) with x<0');
         let sqrt: u128 = integer::upcast(u128_sqrt(value_right.inner));
         return i129Trait::new(sqrt);
+    }
+
+    if opcode == opcodes::POW {
+        assert(!value_left.sign & !value_right.sign, 'cannot pow negative values');
+        let base = value_left.inner;
+        let power = value_right.inner;
+        let m: u128 = BoundedInt::max();
+        let pow = fast_power(base, power, m);
+        return i129Trait::new(pow);
     }
 
     if opcode == opcodes::IS_NN {

--- a/lib/types.cairo
+++ b/lib/types.cairo
@@ -1,0 +1,468 @@
+use box::BoxTrait;
+use nullable::nullable_from_box;
+use option::OptionTrait;
+use traits::Into;
+use traits::TryInto;
+// ====================== INT 129 ======================
+
+// i129 represents a 129-bit integer.
+// The inner field holds the absolute value of the integer.
+// The sign field is true for negative integers, and false for non-negative integers.
+#[derive(Copy, Drop)]
+struct i129 {
+    inner: u128,
+    sign: bool,
+}
+
+/// i129 trait
+trait i129Trait {
+    fn new<T, impl TIntoU128: Into<T, u128>>(inner: T) -> i129;
+    fn zero() -> i129;
+    fn one() -> i129;
+}
+
+impl i129Impl of i129Trait {
+    fn new<T, impl TIntoU128: Into<T, u128>>(inner: T) -> i129 {
+        i129 { inner: inner.into(), sign: bool::False(()) }
+    }
+    fn zero() -> i129 {
+        i129 { inner: 0_u128, sign: bool::False(()) }
+    }
+    fn one() -> i129 {
+        i129 { inner: 1_u128, sign: bool::False(()) }
+    }
+}
+
+impl i129IntoFelt252 of Into<i129, felt252> {
+    fn into(self: i129) -> felt252 {
+        Into::<u128, felt252>::into(self.inner)
+    }
+}
+
+impl i129IntoUsize of Into<i129, usize> {
+    fn into(self: i129) -> usize {
+        Into::<u128, felt252>::into(self.inner).try_into().unwrap()
+    }
+}
+
+impl i129IntoNullable of Into<i129, Nullable<i129>> {
+    fn into(self: i129) -> Nullable<i129> {
+        nullable_from_box(BoxTrait::new(self))
+    }
+}
+
+// Checks if the given i129 integer is zero and has the correct sign.
+// # Arguments
+// * `x` - The i129 integer to check.
+// # Panics
+// Panics if `x` is zero and has a sign that is not false.
+fn i129_check_sign_zero(x: i129) {
+    if x.inner == 0 {
+        assert(x.sign == false, 'sign of 0 must be false');
+    }
+}
+
+// Adds two i129 integers.
+// # Arguments
+// * `a` - The first i129 to add.
+// * `b` - The second i129 to add.
+// # Returns
+// * `i129` - The sum of `a` and `b`.
+fn i129_add(a: i129, b: i129) -> i129 {
+    i129_check_sign_zero(a);
+    i129_check_sign_zero(b);
+    // If both integers have the same sign, 
+    // the sum of their absolute values can be returned.
+    if a.sign == b.sign {
+        let sum = a.inner + b.inner;
+        return i129 { inner: sum, sign: a.sign };
+    } else {
+        // If the integers have different signs, 
+        // the larger absolute value is subtracted from the smaller one.
+        let (larger, smaller) = if a.inner >= b.inner {
+            (a, b)
+        } else {
+            (b, a)
+        };
+        let difference = larger.inner - smaller.inner;
+
+        return i129 { inner: difference, sign: larger.sign };
+    }
+}
+
+// Implements the Add trait for i129.
+impl i129Add of Add<i129> {
+    fn add(lhs: i129, rhs: i129) -> i129 {
+        i129_add(lhs, rhs)
+    }
+}
+
+// Implements the AddEq trait for i129.
+impl i129AddEq of AddEq<i129> {
+    #[inline(always)]
+    fn add_eq(ref self: i129, other: i129) {
+        self = Add::add(self, other);
+    }
+}
+
+// Subtracts two i129 integers.
+// # Arguments
+// * `a` - The first i129 to subtract.
+// * `b` - The second i129 to subtract.
+// # Returns
+// * `i129` - The difference of `a` and `b`.
+fn i129_sub(a: i129, b: i129) -> i129 {
+    i129_check_sign_zero(a);
+    i129_check_sign_zero(b);
+
+    if (b.inner == 0) {
+        return a;
+    }
+
+    // The subtraction of `a` to `b` is achieved by negating `b` sign and adding it to `a`.
+    let neg_b = i129 { inner: b.inner, sign: !b.sign };
+    return a + neg_b;
+}
+
+// Implements the Sub trait for i129.
+impl i129Sub of Sub<i129> {
+    fn sub(lhs: i129, rhs: i129) -> i129 {
+        i129_sub(lhs, rhs)
+    }
+}
+
+// Implements the SubEq trait for i129.
+impl i129SubEq of SubEq<i129> {
+    #[inline(always)]
+    fn sub_eq(ref self: i129, other: i129) {
+        self = Sub::sub(self, other);
+    }
+}
+
+// Multiplies two i129 integers.
+// 
+// # Arguments
+//
+// * `a` - The first i129 to multiply.
+// * `b` - The second i129 to multiply.
+//
+// # Returns
+//
+// * `i129` - The product of `a` and `b`.
+fn i129_mul(a: i129, b: i129) -> i129 {
+    i129_check_sign_zero(a);
+    i129_check_sign_zero(b);
+
+    // The sign of the product is the XOR of the signs of the operands.
+    let sign = a.sign ^ b.sign;
+    // The product is the product of the absolute values of the operands.
+    let inner = a.inner * b.inner;
+    return i129 { inner, sign };
+}
+
+// Implements the Mul trait for i129.
+impl i129Mul of Mul<i129> {
+    fn mul(lhs: i129, rhs: i129) -> i129 {
+        i129_mul(lhs, rhs)
+    }
+}
+
+// Implements the MulEq trait for i129.
+impl i129MulEq of MulEq<i129> {
+    #[inline(always)]
+    fn mul_eq(ref self: i129, other: i129) {
+        self = Mul::mul(self, other);
+    }
+}
+
+// Divides the first i129 by the second i129.
+// # Arguments
+// * `a` - The i129 dividend.
+// * `b` - The i129 divisor.
+// # Returns
+// * `i129` - The quotient of `a` and `b`.
+fn i129_div(a: i129, b: i129) -> i129 {
+    i129_check_sign_zero(a);
+    // Check that the divisor is not zero.
+    assert(b.inner != 0, 'b can not be 0');
+
+    // The sign of the quotient is the XOR of the signs of the operands.
+    let sign = a.sign ^ b.sign;
+
+    if (sign == false) {
+        // If the operands are positive, the quotient is simply their absolute value quotient.
+        return i129 { inner: a.inner / b.inner, sign: sign };
+    }
+
+    // If the operands have different signs, rounding is necessary.
+    // First, check if the quotient is an integer.
+    if (a.inner % b.inner == 0) {
+        return i129 { inner: a.inner / b.inner, sign: sign };
+    }
+
+    // If the quotient is not an integer, multiply the dividend by 10 to move the decimal point over.
+    let quotient = (a.inner * 10) / b.inner;
+    let last_digit = quotient % 10;
+
+    // Check the last digit to determine rounding direction.
+    if (last_digit <= 5) {
+        return i129 { inner: quotient / 10, sign: sign };
+    } else {
+        return i129 { inner: (quotient / 10) + 1, sign: sign };
+    }
+}
+
+// Implements the Div trait for i129.
+impl i129Div of Div<i129> {
+    fn div(lhs: i129, rhs: i129) -> i129 {
+        i129_div(lhs, rhs)
+    }
+}
+
+// Implements the DivEq trait for i129.
+impl i129DivEq of DivEq<i129> {
+    #[inline(always)]
+    fn div_eq(ref self: i129, other: i129) {
+        self = Div::div(self, other);
+    }
+}
+
+// Calculates the remainder of the division of a first i129 by a second i129.
+// # Arguments
+// * `a` - The i129 dividend.
+// * `b` - The i129 divisor.
+// # Returns
+// * `i129` - The remainder of dividing `a` by `b`.
+fn i129_rem(a: i129, b: i129) -> i129 {
+    i129_check_sign_zero(a);
+    // Check that the divisor is not zero.
+    assert(b.inner != 0, 'b can not be 0');
+
+    return a - (b * (a / b));
+}
+
+// Implements the Rem trait for i129.
+impl i129Rem of Rem<i129> {
+    fn rem(lhs: i129, rhs: i129) -> i129 {
+        i129_rem(lhs, rhs)
+    }
+}
+
+// Implements the RemEq trait for i129.
+impl i129RemEq of RemEq<i129> {
+    #[inline(always)]
+    fn rem_eq(ref self: i129, other: i129) {
+        self = Rem::rem(self, other);
+    }
+}
+
+// Calculates both the quotient and the remainder of the division of a first i129 by a second i129.
+// # Arguments
+// * `a` - The i129 dividend.
+// * `b` - The i129 divisor.
+// # Returns
+// * `(i129, i129)` - A tuple containing the quotient and the remainder of dividing `a` by `b`.
+fn i129_div_rem(a: i129, b: i129) -> (i129, i129) {
+    let quotient = i129_div(a, b);
+    let remainder = i129_rem(a, b);
+
+    return (quotient, remainder);
+}
+
+// Compares two i129 integers for equality.
+// # Arguments
+// * `a` - The first i129 integer to compare.
+// * `b` - The second i129 integer to compare.
+// # Returns
+// * `bool` - `true` if the two integers are equal, `false` otherwise.
+fn i129_eq(a: i129, b: i129) -> bool {
+    // Check if the two integers have the same sign and the same absolute value.
+    if a.sign == b.sign & a.inner == b.inner {
+        return true;
+    }
+
+    return false;
+}
+
+// Compares two i129 integers for inequality.
+// # Arguments
+// * `a` - The first i129 integer to compare.
+// * `b` - The second i129 integer to compare.
+// # Returns
+// * `bool` - `true` if the two integers are not equal, `false` otherwise.
+fn i129_ne(a: i129, b: i129) -> bool {
+    // The result is the inverse of the equal function.
+    return !i129_eq(a, b);
+}
+
+// Implements the PartialEq trait for i129.
+impl i129PartialEq of PartialEq<i129> {
+    fn eq(lhs: i129, rhs: i129) -> bool {
+        i129_eq(lhs, rhs)
+    }
+
+    fn ne(lhs: i129, rhs: i129) -> bool {
+        i129_ne(lhs, rhs)
+    }
+}
+
+// Compares two i129 integers for greater than.
+// # Arguments
+// * `a` - The first i129 integer to compare.
+// * `b` - The second i129 integer to compare.
+// # Returns
+// * `bool` - `true` if `a` is greater than `b`, `false` otherwise.
+fn i129_gt(a: i129, b: i129) -> bool {
+    // Check if `a` is negative and `b` is positive.
+    if (a.sign & !b.sign) {
+        return false;
+    }
+    // Check if `a` is positive and `b` is negative.
+    if (!a.sign & b.sign) {
+        return true;
+    }
+    // If `a` and `b` have the same sign, compare their absolute values.
+    if (a.sign & b.sign) {
+        return a.inner < b.inner;
+    } else {
+        return a.inner > b.inner;
+    }
+}
+
+// Determines whether the first i129 is less than the second i129.
+// # Arguments
+// * `a` - The i129 to compare against the second i129.
+// * `b` - The i129 to compare against the first i129.
+// # Returns
+// * `bool` - `true` if `a` is less than `b`, `false` otherwise.
+fn i129_lt(a: i129, b: i129) -> bool {
+    // The result is the inverse of the greater than function.
+    return !i129_gt(a, b);
+}
+
+// Checks if the first i129 integer is less than or equal to the second.
+// # Arguments
+// * `a` - The first i129 integer to compare.
+// * `b` - The second i129 integer to compare.
+// # Returns
+// * `bool` - `true` if `a` is less than or equal to `b`, `false` otherwise.
+fn i129_le(a: i129, b: i129) -> bool {
+    if (a == b | i129_lt(a, b) == true) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// Checks if the first i129 integer is greater than or equal to the second.
+// # Arguments
+// * `a` - The first i129 integer to compare.
+// * `b` - The second i129 integer to compare.
+// # Returns
+// * `bool` - `true` if `a` is greater than or equal to `b`, `false` otherwise.
+fn i129_ge(a: i129, b: i129) -> bool {
+    if (a == b | i129_gt(a, b) == true) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// Implements the PartialOrd trait for i129.
+impl i129PartialOrd of PartialOrd<i129> {
+    fn le(lhs: i129, rhs: i129) -> bool {
+        i129_le(lhs, rhs)
+    }
+    fn ge(lhs: i129, rhs: i129) -> bool {
+        i129_ge(lhs, rhs)
+    }
+
+    fn lt(lhs: i129, rhs: i129) -> bool {
+        i129_lt(lhs, rhs)
+    }
+    fn gt(lhs: i129, rhs: i129) -> bool {
+        i129_gt(lhs, rhs)
+    }
+}
+
+// Negates the given i129 integer.
+// # Arguments
+// * `x` - The i129 integer to negate.
+// # Returns
+// * `i129` - The negation of `x`.
+fn i129_neg(x: i129) -> i129 {
+    // The negation of an integer is obtained by flipping its sign.
+    return i129 { inner: x.inner, sign: !x.sign };
+}
+
+// Implements the Neg trait for i129.
+impl i129Neg of Neg<i129> {
+    fn neg(a: i129) -> i129 {
+        i129_neg(a)
+    }
+}
+
+// Computes the absolute value of the given i129 integer.
+// # Arguments
+// * `x` - The i129 integer to compute the absolute value of.
+// # Returns
+// * `i129` - The absolute value of `x`.
+fn i129_abs(x: i129) -> i129 {
+    return i129 { inner: x.inner, sign: false };
+}
+
+// Computes the maximum between two i129 integers.
+// # Arguments
+// * `a` - The first i129 integer to compare.
+// * `b` - The second i129 integer to compare.
+// # Returns
+// * `i129` - The maximum between `a` and `b`.
+fn i129_max(a: i129, b: i129) -> i129 {
+    if (a > b) {
+        return a;
+    } else {
+        return b;
+    }
+}
+
+// Computes the minimum between two i129 integers.
+// # Arguments
+// * `a` - The first i129 integer to compare.
+// * `b` - The second i129 integer to compare.
+// # Returns
+// * `i129` - The minimum between `a` and `b`.
+fn i129_min(a: i129, b: i129) -> i129 {
+    if (a < b) {
+        return a;
+    } else {
+        return b;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::i129Trait;
+
+    #[test]
+    fn test_i129_new() {
+        let x = i129Trait::new(0_u8);
+        assert(x.inner == 0, 'expected inner 0');
+        assert(!x.sign, 'expected sign false');
+
+        let x = i129Trait::new(1_u8);
+        assert(x.inner == 1, 'expected inner 1');
+        assert(!x.sign, 'expected sign false');
+
+        let x = -i129Trait::new(1_u8);
+        assert(x.inner == 1, 'expected inner 1');
+        assert(x.sign, 'expected sign true');
+
+        let x = i129Trait::new(0xffffffffffffffffffffffffffffffff_u128);
+        assert(x.inner == 0xffffffffffffffffffffffffffffffff, 'expected inner 2**128');
+        assert(!x.sign, 'expected sign false');
+
+        let x = -i129Trait::new(0xffffffffffffffffffffffffffffffff_u128);
+        assert(x.inner == 0xffffffffffffffffffffffffffffffff, 'expected inner 2**128');
+        assert(x.sign, 'expected sign true');
+    }
+}


### PR DESCRIPTION
### Description 
Augments the currents binary tree operator (BTO), adding a three opcodes as well as signed integers to the existing list: ABS, IS_NN and POW.

### Approach
The opcodes are integrated using tests from Cairo 0.X implementation. The BTO type is updated to i129 and tests are updated in order to pass.

### Checklist
- [x] Change BTO type from u128 to i129
- [x] Update current validated tests of the BTO for opcodes to Cairo 1.0
- [x] Implement the opcodes in order to pass the updated tests 